### PR TITLE
Fix invalid memory address or nil pointer dereference

### DIFF
--- a/proctord/server/api.go
+++ b/proctord/server/api.go
@@ -1,17 +1,21 @@
 package server
 
 import (
-	"proctor/proctord/instrumentation"
-	"time"
-
 	"proctor/proctord/config"
+	"proctor/proctord/instrumentation"
 	"proctor/proctord/logger"
+	"proctor/proctord/redis"
+	"proctor/proctord/storage/postgres"
+	"time"
 
 	"github.com/tylerb/graceful"
 	"github.com/urfave/negroni"
 )
 
 func Start() error {
+	redisClient := redis.NewClient()
+	postgresClient := postgres.NewClient()
+
 	err := instrumentation.InitNewRelic()
 	if err != nil {
 		logger.Fatal(err)
@@ -19,7 +23,7 @@ func Start() error {
 	appPort := ":" + config.AppPort()
 
 	server := negroni.New(negroni.NewRecovery())
-	router, err := NewRouter()
+	router, err := NewRouter(postgresClient, redisClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix runtime error: invalid memory address or nil pointer dereference whenever closing server, postgresClient [signal SIGSEGV: segmentation violation]