### PR TITLE
Client update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,17 +40,24 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.12
+          go-version: 1.16
 
       - name: Test
         run: make db.setup test-with-race
 
   release:
     runs-on: ubuntu-latest
-
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - name: Release
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - run: ./scripts/release.sh
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Release
+        run: ./scripts/release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_REPO_PAT }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 builds:
-- env:
+- main: ./exec/cli/cli.go
+  env:
   - CGO_ENABLED=0
 archives:
   -

--- a/daemon/client_test.go
+++ b/daemon/client_test.go
@@ -157,7 +157,7 @@ func (s *ClientTestSuite) TestListProcsReturnClientSideTimeoutError() {
 
 	procList, err := s.testClient.ListProcs()
 
-	assert.Equal(t, errors.New("Connection Timeout!!!\nGet http://proctor.example.com/jobs/metadata: Unable to reach http://proctor.example.com/\nPlease check your Internet/VPN connection for connectivity to ProctorD."), err)
+	assert.Equal(t, errors.New("Connection Timeout!!!\nGet \"http://proctor.example.com/jobs/metadata\": Unable to reach http://proctor.example.com/\nPlease check your Internet/VPN connection for connectivity to ProctorD."), err)
 	assert.Equal(t, []proc_metadata.Metadata{}, procList)
 	s.mockConfigLoader.AssertExpectations(t)
 }
@@ -190,7 +190,7 @@ func (s *ClientTestSuite) TestListProcsReturnClientSideConnectionError() {
 
 	procList, err := s.testClient.ListProcs()
 
-	assert.Equal(t, errors.New("Network Error!!!\nGet http://proctor.example.com/jobs/metadata: Unknown Error"), err)
+	assert.Equal(t, errors.New("Network Error!!!\nGet \"http://proctor.example.com/jobs/metadata\": Unknown Error"), err)
 	assert.Equal(t, []proc_metadata.Metadata{}, procList)
 	s.mockConfigLoader.AssertExpectations(t)
 }
@@ -501,7 +501,7 @@ func (s *ClientTestSuite) TestExecuteProcsReturnClientSideConnectionError() {
 	response, err := s.testClient.ExecuteProc("run-sample", map[string]string{"SAMPLE_ARG1": "sample-value"})
 
 	assert.Equal(t, "", response)
-	assert.Equal(t, errors.New("Network Error!!!\nPost http://proctor.example.com/jobs/execute: Unknown Error"), err)
+	assert.Equal(t, errors.New("Network Error!!!\nPost \"http://proctor.example.com/jobs/execute\": Unknown Error"), err)
 	s.mockConfigLoader.AssertExpectations(t)
 }
 
@@ -667,7 +667,7 @@ func (s *ClientTestSuite) TestGetDefinitiveProcExecutionStatusForHTTPRequestFail
 
 	procExecutionStatus, err := s.testClient.GetDefinitiveProcExecutionStatus("some-proc-name")
 
-	assert.Equal(t, errors.New("Connection Timeout!!!\nGet http://proctor.example.com/jobs/execute/some-proc-name/status: Unable to reach http://proctor.example.com/\nPlease check your Internet/VPN connection for connectivity to ProctorD."), err)
+	assert.Equal(t, errors.New("Connection Timeout!!!\nGet \"http://proctor.example.com/jobs/execute/some-proc-name/status\": Unable to reach http://proctor.example.com/\nPlease check your Internet/VPN connection for connectivity to ProctorD."), err)
 	s.mockConfigLoader.AssertExpectations(t)
 	assert.Equal(t, "", procExecutionStatus)
 }

--- a/scripts/proctor.rb.tpl
+++ b/scripts/proctor.rb.tpl
@@ -6,8 +6,6 @@ class Proctor < Formula
   sha256 "{{ .SHA }}"
   head "https://github.com/gojek/proctor.git"
 
-  bottle :unneeded
-
   def install
     bin.install "proctor"
   end

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,11 +6,13 @@ curl -sL https://git.io/goreleaser | bash
 SHA=$(cat dist/checksums.txt | grep Darwin_x86_64 | awk '{ print $1}')
 echo " REF_NAME => $GITHUB_REF_NAME"
 go run scripts/proctor_template.go "$GITHUB_REF_NAME" "$SHA"
-rm -rf homebrew-gojek
-git clone "https://$GITHUB_TOKEN:@github.com/gojek/homebrew-gojek.git"
-cp scripts/proctor.rb homebrew-gojek/Formula/proctor.rb
-cd homebrew-gojek
+rm -rf homebrew-tap
+git clone "https://$GITHUB_TOKEN:@github.com/gojek/homebrew-tap.git"
+cp scripts/proctor.rb homebrew-tap/Formula/proctor.rb
+cd homebrew-tap
+git config user.name "Github Actions"
+git config user.email "<>"
 git add .
 git commit -m "[GH Actions] updating brew formula for release $GITHUB_REF_NAME"
-#git push --force --quiet "https://$GITHUB_TOKEN:@github.com/gojektech/homebrew-gojek.git"
+git push --force --quiet "https://$GITHUB_TOKEN:@github.com/gojektech/homebrew-tap.git"
 


### PR DESCRIPTION
Apple Silicon Macs require a minimum version of [go1.16](https://go.dev/doc/go1.16#darwin)
Updates Goreleaser to use 1.16 to build client binaries compatible with Apple Silicon